### PR TITLE
Add helmet hunger toggle command

### DIFF
--- a/src/main/java/committee/nova/mods/avaritia/init/config/ModConfig.java
+++ b/src/main/java/committee/nova/mods/avaritia/init/config/ModConfig.java
@@ -23,6 +23,7 @@ public class ModConfig {
     public static final ForgeConfigSpec.BooleanValue isSwordAttackEndless;
     public static final ForgeConfigSpec.IntValue subArrowDamage;
     public static final ForgeConfigSpec.IntValue axeChainCount;
+    public static final ForgeConfigSpec.BooleanValue helmetKeepHungerFull;
     public static final ForgeConfigSpec.IntValue pickAxeBreakRange;
     public static final ForgeConfigSpec.IntValue shovelBreakRange;
     public static final ForgeConfigSpec.IntValue neutronCollectorProductTick;
@@ -64,6 +65,7 @@ public class ModConfig {
         isSwordAttackEndless = buildBoolean(common, "Is Sword Cause Endless damage", true, "Does the right key cause infinity damage");
         subArrowDamage = buildInt(common, "Sub Arrow Damage", 10000, 100, 100000, "Infinity bow scattering light arrow damage");
         axeChainCount = buildInt(common, "Axe Chain Count", 64, 16, 128, "Chain number of endless axe cutting trees");
+        helmetKeepHungerFull = buildBoolean(common, "Helmet Keep Hunger Full", true, "Infinity helmet keeps food full, otherwise hunger decreases but never reaches zero");
         foodTime = buildDouble(common, "Food Time", 1d, 0.1d, 5d, "Food effect time scaling factor");
         pickAxeBreakRange = buildInt(common, "PickAxe Break Range", 8, 2, 32, "The range of Infinity PickAxe can break");
         shovelBreakRange = buildInt(common, "Shovel Break Range", 8, 2, 32, "The range of Infinity Shovel can break");

--- a/src/main/java/committee/nova/mods/avaritia/init/handler/AbilityHandler.java
+++ b/src/main/java/committee/nova/mods/avaritia/init/handler/AbilityHandler.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Collections2;
 import com.google.common.collect.Lists;
 import committee.nova.mods.avaritia.api.utils.PlayerUtils;
 import committee.nova.mods.avaritia.common.item.tools.InfinityArmorItem;
+import committee.nova.mods.avaritia.init.config.ModConfig;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.Mth;
 import net.minecraft.world.effect.MobEffectInstance;
@@ -100,8 +101,12 @@ public class AbilityHandler {
         if (hasHelmet) {
             if (entitiesWithHelmets.contains(key)) {
                 player.setAirSupply(300);
-                player.getFoodData().setFoodLevel(20);
-                player.getFoodData().setSaturation(20f);
+                if (ModConfig.helmetKeepHungerFull.get()) {
+                    player.getFoodData().setFoodLevel(20);
+                    player.getFoodData().setSaturation(20f);
+                } else if (player.getFoodData().getFoodLevel() <= 0) {
+                    player.getFoodData().setFoodLevel(1);
+                }
                 MobEffectInstance nv = player.getEffect(MobEffects.NIGHT_VISION);
                 if (nv == null) {
                     nv = new MobEffectInstance(MobEffects.NIGHT_VISION, 300, 0, false, false);

--- a/src/main/java/committee/nova/mods/avaritia/init/handler/CommandHandler.java
+++ b/src/main/java/committee/nova/mods/avaritia/init/handler/CommandHandler.java
@@ -1,0 +1,42 @@
+package committee.nova.mods.avaritia.init.handler;
+
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import committee.nova.mods.avaritia.Const;
+import committee.nova.mods.avaritia.init.config.ModConfig;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+import net.minecraftforge.event.RegisterCommandsEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod.EventBusSubscriber(modid = Const.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
+public class CommandHandler {
+
+    @SubscribeEvent
+    public static void onRegisterCommands(RegisterCommandsEvent event) {
+        LiteralArgumentBuilder<CommandSourceStack> cmd = Commands.literal("helmetHunger")
+                .requires(s -> s.hasPermission(2))
+                .executes(ctx -> toggle(ctx.getSource()))
+                .then(Commands.literal("on").executes(ctx -> set(ctx.getSource(), true)))
+                .then(Commands.literal("off").executes(ctx -> set(ctx.getSource(), false)));
+        event.getDispatcher().register(cmd);
+    }
+
+    private static int toggle(CommandSourceStack source) {
+        boolean newVal = !ModConfig.helmetKeepHungerFull.get();
+        ModConfig.helmetKeepHungerFull.set(newVal);
+        source.sendSuccess(() -> Component.translatable(newVal
+                ? "command.avaritia.helmet_hunger.enabled"
+                : "command.avaritia.helmet_hunger.disabled"), true);
+        return 1;
+    }
+
+    private static int set(CommandSourceStack source, boolean value) {
+        ModConfig.helmetKeepHungerFull.set(value);
+        source.sendSuccess(() -> Component.translatable(value
+                ? "command.avaritia.helmet_hunger.enabled"
+                : "command.avaritia.helmet_hunger.disabled"), true);
+        return 1;
+    }
+}

--- a/src/main/resources/assets/avaritia/lang/en_us.json
+++ b/src/main/resources/assets/avaritia/lang/en_us.json
@@ -350,5 +350,7 @@
   "gui.avaritia.rule.mod_fluid": "Mod(fluid): %d",
   "gui.avaritia.rule.any_item": "Any item",
   "gui.avaritia.rule.any_fluid": "Any fluid",
-  "gui.avaritia.rule.tip": "Select with the mouse wheel"
+  "gui.avaritia.rule.tip": "Select with the mouse wheel",
+  "command.avaritia.helmet_hunger.enabled": "Helmet hunger lock enabled",
+  "command.avaritia.helmet_hunger.disabled": "Helmet hunger lock disabled"
 }

--- a/src/main/resources/assets/avaritia/lang/zh_cn.json
+++ b/src/main/resources/assets/avaritia/lang/zh_cn.json
@@ -340,5 +340,8 @@
   "gui.avaritia.rule.mod_fluid": "模组(流体): %d",
   "gui.avaritia.rule.any_item": "任意物品",
   "gui.avaritia.rule.any_fluid": "任意流体",
-  "gui.avaritia.rule.tip": "用鼠标滚轮选择"
+  "gui.avaritia.rule.tip": "用鼠标滚轮选择",
+  "command.avaritia.helmet_hunger.enabled": "头盔饱食锁定已启用",
+  "command.avaritia.helmet_hunger.disabled": "头盔饱食锁定已停用"
 }
+


### PR DESCRIPTION
## Summary
- add command `helmetHunger` to switch `helmetKeepHungerFull` without restart
- add English and Chinese translations for the command messages

## Testing
- `./gradlew test` *(fails: network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687cd0246bb88320a691e2097983935a