### PR TITLE
Add hunger toggle command

### DIFF
--- a/src/main/java/committee/nova/mods/avaritia/init/handler/AbilityHandler.java
+++ b/src/main/java/committee/nova/mods/avaritia/init/handler/AbilityHandler.java
@@ -11,6 +11,7 @@ import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.phys.Vec3;
+import committee.nova.mods.avaritia.init.handler.HungerCommandHandler;
 import net.minecraftforge.event.entity.living.LivingDeathEvent;
 import net.minecraftforge.event.entity.living.LivingEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
@@ -100,8 +101,12 @@ public class AbilityHandler {
         if (hasHelmet) {
             if (entitiesWithHelmets.contains(key)) {
                 player.setAirSupply(300);
-                player.getFoodData().setFoodLevel(20);
-                player.getFoodData().setSaturation(20f);
+                if (HungerCommandHandler.keepFull()) {
+                    player.getFoodData().setFoodLevel(20);
+                    player.getFoodData().setSaturation(20f);
+                } else if (player.getFoodData().getFoodLevel() <= 1) {
+                    player.getFoodData().setFoodLevel(1);
+                }
                 MobEffectInstance nv = player.getEffect(MobEffects.NIGHT_VISION);
                 if (nv == null) {
                     nv = new MobEffectInstance(MobEffects.NIGHT_VISION, 300, 0, false, false);

--- a/src/main/java/committee/nova/mods/avaritia/init/handler/HungerCommandHandler.java
+++ b/src/main/java/committee/nova/mods/avaritia/init/handler/HungerCommandHandler.java
@@ -1,0 +1,46 @@
+package committee.nova.mods.avaritia.init.handler;
+
+import com.mojang.brigadier.CommandDispatcher;
+import committee.nova.mods.avaritia.Const;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Player;
+import net.minecraftforge.event.entity.living.LivingEvent;
+import net.minecraftforge.event.RegisterCommandsEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
+
+@Mod.EventBusSubscriber(modid = Const.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
+public class HungerCommandHandler {
+    private static boolean keepFull = true;
+
+    public static boolean keepFull() {
+        return keepFull;
+    }
+
+    @SubscribeEvent
+    public static void onRegister(RegisterCommandsEvent event) {
+        CommandDispatcher<CommandSourceStack> dispatcher = event.getDispatcher();
+        dispatcher.register(Commands.literal("avaritiahunger")
+                .requires(cs -> true)
+                .executes(ctx -> toggle(ctx.getSource())));
+    }
+
+    private static int toggle(CommandSourceStack source) {
+        keepFull = !keepFull;
+        source.sendSystemMessage(Component.translatable(keepFull ?
+                "command.avaritia.hunger.enabled" :
+                "command.avaritia.hunger.disabled"));
+        return 1;
+    }
+
+    @SubscribeEvent
+    public static void tick(LivingEvent.LivingTickEvent event) {
+        if (!keepFull && event.getEntity() instanceof Player player) {
+            if (player.getFoodData().getFoodLevel() <= 1) {
+                player.getFoodData().setFoodLevel(1);
+            }
+        }
+    }
+}

--- a/src/main/resources/assets/avaritia/lang/en_us.json
+++ b/src/main/resources/assets/avaritia/lang/en_us.json
@@ -350,5 +350,8 @@
   "gui.avaritia.rule.mod_fluid": "Mod(fluid): %d",
   "gui.avaritia.rule.any_item": "Any item",
   "gui.avaritia.rule.any_fluid": "Any fluid",
-  "gui.avaritia.rule.tip": "Select with the mouse wheel"
+  "gui.avaritia.rule.tip": "Select with the mouse wheel",
+  "command.avaritia.hunger.enabled": "Infinite hunger enabled",
+  "command.avaritia.hunger.disabled": "Infinite hunger disabled"
 }
+

--- a/src/main/resources/assets/avaritia/lang/zh_cn.json
+++ b/src/main/resources/assets/avaritia/lang/zh_cn.json
@@ -340,5 +340,8 @@
   "gui.avaritia.rule.mod_fluid": "模组(流体): %d",
   "gui.avaritia.rule.any_item": "任意物品",
   "gui.avaritia.rule.any_fluid": "任意流体",
-  "gui.avaritia.rule.tip": "用鼠标滚轮选择"
+  "gui.avaritia.rule.tip": "用鼠标滚轮选择",
+  "command.avaritia.hunger.enabled": "无尽饱食已开启",
+  "command.avaritia.hunger.disabled": "无尽饱食已关闭"
 }
+

--- a/src/main/resources/assets/avaritia/lang/zh_tw.json
+++ b/src/main/resources/assets/avaritia/lang/zh_tw.json
@@ -223,5 +223,8 @@
   "config.jade.plugin_avaritia.nether": "煉獄合成",
   "config.jade.plugin_avaritia.extreme": "終焉合成",
   "rarity.legend.name": "傳說",
-  "rarity.cosmic.name": "無盡"
+  "rarity.cosmic.name": "無盡",
+  "command.avaritia.hunger.enabled": "無盡飽食已啟用",
+  "command.avaritia.hunger.disabled": "無盡飽食已停用"
 }
+


### PR DESCRIPTION
## Summary
- add `HungerCommandHandler` to toggle auto feeding
- integrate hunger toggle with helmet ability
- add translations for hunger toggle messages

## Testing
- `./gradlew classes`

------
https://chatgpt.com/codex/tasks/task_e_687cd9083ff4832085c2690b0bcccc8e