### PR TITLE
Add config-backed hunger toggle

### DIFF
--- a/src/main/java/committee/nova/mods/avaritia/init/config/ModConfig.java
+++ b/src/main/java/committee/nova/mods/avaritia/init/config/ModConfig.java
@@ -32,6 +32,8 @@ public class ModConfig {
     public static final ForgeConfigSpec.IntValue bladeSlashRadius;
     public static final ForgeConfigSpec.BooleanValue internalInfinityCatalystCraft;
 
+    public static final ForgeConfigSpec.BooleanValue keepHungerFull;
+
     public static final ForgeConfigSpec.IntValue neutronPileEmc;
     public static final ForgeConfigSpec.IntValue vanillaTotemEmc;
 
@@ -94,6 +96,7 @@ public class ModConfig {
         CHANNEL_FULL_UPDATE_RATE = buildInt(common, "FullUpdate Rate", 40, 20, 1200, "");
         common.pop();
         common.push("misc");
+        keepHungerFull = buildBoolean(common, "Keep Hunger Full", false, "Keep hunger constantly full when enabled");
         useAdvanceTooltips = buildBoolean(common, "Use Advance Tooltips", false, "For develop");
         common.pop();
         COMMON = common.build();

--- a/src/main/java/committee/nova/mods/avaritia/init/handler/HungerCommandHandler.java
+++ b/src/main/java/committee/nova/mods/avaritia/init/handler/HungerCommandHandler.java
@@ -2,6 +2,7 @@ package committee.nova.mods.avaritia.init.handler;
 
 import com.mojang.brigadier.CommandDispatcher;
 import committee.nova.mods.avaritia.Const;
+import committee.nova.mods.avaritia.init.config.ModConfig;
 import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.Commands;
 import net.minecraft.network.chat.Component;
@@ -13,7 +14,7 @@ import net.minecraftforge.fml.common.Mod;
 
 @Mod.EventBusSubscriber(modid = Const.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class HungerCommandHandler {
-    private static boolean keepFull = true;
+    private static boolean keepFull = ModConfig.keepHungerFull.get();
 
     public static boolean keepFull() {
         return keepFull;
@@ -29,6 +30,8 @@ public class HungerCommandHandler {
 
     private static int toggle(CommandSourceStack source) {
         keepFull = !keepFull;
+        ModConfig.keepHungerFull.set(keepFull);
+        ModConfig.keepHungerFull.save();
         source.sendSystemMessage(Component.translatable(keepFull ?
                 "command.avaritia.hunger.enabled" :
                 "command.avaritia.hunger.disabled"));


### PR DESCRIPTION
## Summary
- add `keepHungerFull` option to `ModConfig`
- load and persist hunger toggle via config in `HungerCommandHandler`

## Testing
- `./gradlew help --no-daemon` *(fails: java executable missing)*

------
https://chatgpt.com/codex/tasks/task_e_687d1fdf1f7c832085e890343f0a58eb